### PR TITLE
don't always include --user

### DIFF
--- a/fuzzy-sys.plugin.zsh
+++ b/fuzzy-sys.plugin.zsh
@@ -23,7 +23,7 @@ EOF
 preview_service() {
     case $1 in
         --system|--user)
-            awk '{print $1}' | fzf --multi --ansi --preview="SYSTEMD_COLORS=1 systemctl $1 -n 30 --user status --no-pager {}" ;;
+            awk '{print $1}' | fzf --multi --ansi --preview="SYSTEMD_COLORS=1 systemctl $1 -n 30 status --no-pager {}" ;;
         *) exit 1
     esac
 }


### PR DESCRIPTION
The `case` statement is checking for `--system` and `--user` in `$1` and the command includes `$1` and the string `--user`. It should only include `$1`. 

Fixes #6 